### PR TITLE
Use a frontend-friendly hashed icon name

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,9 @@ module.exports = function(name, opts) {
     extensions: ['.svg']
   }));
 
-  const content = require.cache[mod] || (require.cache[mod] = makeSymbol(fs.readFileSync(mod, 'utf-8'), mod));
+  const content = require.cache[mod] || (require.cache[mod] = makeSymbol(fs.readFileSync(mod, 'utf-8'), name));
 
-  const instantiate = ltx.parse(`<svg><use xlink:href="#symbol-${murmurhash.v3(mod)}"/></svg>`);
+  const instantiate = ltx.parse(`<svg><use xlink:href="#symbol-${murmurhash.v3(name)}"/></svg>`);
 
   Object.assign(instantiate.attrs, opts.hash);
 
@@ -30,14 +30,14 @@ module.exports = function(name, opts) {
   }
 }
 
-function makeSymbol(xml, mod) {
+function makeSymbol(xml, name) {
   const symbol = ltx.parse(xml);
   if (symbol.name != 'svg') {
     throw new TypeError("Input must be an SVG");
   }
 
   symbol.name = 'symbol';
-  symbol.attrs.id = `symbol-${murmurhash.v3(mod)}`;
+  symbol.attrs.id = `symbol-${murmurhash.v3(name)}`;
   delete symbol.attrs.xmlns;
   delete symbol.attrs.width;
   delete symbol.attrs.height;

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ const ltx = require('ltx');
 const resolve = require('resolve');
 const murmurhash = require('murmurhash');
 
-const id = `symbol-${murmurhash.v3(resolve.sync("./test.svg"))}`;
+const id = `symbol-${murmurhash.v3("./test.svg")}`;
 
 tap.test('register helper', function (t) {
 	handlebars.registerHelper('icon', icon);


### PR DESCRIPTION
BREAKING CHANGE: this changes caching to be a bit less node-like, using
the input module name as a cache key rather than the resolved file name.
However, previously the lookup wasn't relative to the source filename so
they actually formed a different namespace already.

BREAKING CHANGE: the symbol IDs generated are different.
